### PR TITLE
散歩記録のnew/create機能を実装

### DIFF
--- a/app/controllers/walk_records_controller.rb
+++ b/app/controllers/walk_records_controller.rb
@@ -1,0 +1,24 @@
+class WalkRecordsController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @walk_record = WalkRecord.new
+  end
+
+  def create
+    @walk_record = current_user.walk_records.build(walk_record_params)
+
+    if @walk_record.save
+      redirect_to root_path, notice: "散歩記録を投稿しました"
+    else
+      flash.now[:alert] = "散歩記録を投稿できませんでした"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def walk_record_params
+    params.require(:walk_record).permit(:title, :body, :walked_on, :mood)
+  end
+end

--- a/app/models/walk_record.rb
+++ b/app/models/walk_record.rb
@@ -1,7 +1,7 @@
 class WalkRecord < ApplicationRecord
   belongs_to :user
 
-  enum :mood, { good: 0, normal: 1, tired: 2, sad: 3 }
+  enum mood: { good: 0, normal: 1, bad: 2, excited: 3, tired: 4 }
 
   validates :walked_on, presence: true
   validates :body, presence: true

--- a/app/views/walk_records/new.html.erb
+++ b/app/views/walk_records/new.html.erb
@@ -1,0 +1,78 @@
+<div class="min-h-screen bg-base-200 px-4 py-6">
+  <div class="mx-auto w-full max-w-md">
+    <div class="mb-6 text-center">
+      <h1 class="text-2xl font-bold">散歩記録を投稿する</h1>
+      <p class="mt-2 text-sm text-base-content/70">
+        今日のおさんぽを記録してみましょう
+      </p>
+    </div>
+
+    <% if @walk_record.errors.any? %>
+      <div class="alert alert-error mb-4 shadow-sm">
+        <div>
+          <span class="font-bold">
+            <%= @walk_record.errors.count %>件のエラーがあります
+          </span>
+          <ul class="mt-2 list-disc pl-5 text-sm">
+            <% @walk_record.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="card bg-base-100 shadow-md">
+      <div class="card-body">
+        <%= form_with model: @walk_record, local: true, class: "space-y-4" do |f| %>
+          <div class="form-control">
+            <%= f.label :title, class: "label" do %>
+              <span class="label-text font-semibold">タイトル</span>
+            <% end %>
+            <%= f.text_field :title,
+                  placeholder: "例：朝のお散歩",
+                  class: "input input-bordered w-full" %>
+          </div>
+
+          <div class="form-control">
+            <%= f.label :walked_on, class: "label" do %>
+              <span class="label-text font-semibold">散歩した日</span>
+            <% end %>
+            <%= f.date_field :walked_on,
+                  class: "input input-bordered w-full" %>
+          </div>
+
+          <div class="form-control">
+            <%= f.label :mood, class: "label" do %>
+              <span class="label-text font-semibold">気分</span>
+            <% end %>
+            <%= f.select :mood,
+                  [
+                    ["良い", "good"],
+                    ["普通", "normal"],
+                    ["悪い", "bad"],
+                    ["楽しい", "excited"],
+                    ["疲れた", "tired"]
+                  ],
+                  {},
+                  class: "select select-bordered w-full" %>
+          </div>
+
+          <div class="form-control">
+            <%= f.label :body, class: "label" do %>
+              <span class="label-text font-semibold">ひとことメモ</span>
+            <% end %>
+            <%= f.text_area :body,
+                  rows: 5,
+                  placeholder: "今日のおさんぽのことを書いてみましょう",
+                  class: "textarea textarea-bordered w-full" %>
+          </div>
+
+          <div class="pt-2">
+            <%= f.submit "投稿する", class: "btn btn-primary w-full" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   root "pages#home"
+
+  resources :walk_records, only: %i[new create]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### 概要
散歩記録を新規投稿できるよう実装。

### 変更内容
- WalkRecordsControllerを作成
  ( g controller WalkRecords )
- routes.rb に walk_records の new/create を追加
  (resources :walk_records, only: %i[new create])
- new アクションで投稿フォームを表示
- create アクションで散歩記録を保存
- 投稿フォームを作成(app/views/walk_records/new.html.erb)
- strong parameters を設定
  (permit(:title, :body, :walked_on, :mood))
- ログイン中のユーザーに紐づけて保存するよう実装
  (current_user.walk_records.build.....)

### 動作確認
コンソールにて確認
- ログイン後に投稿画面へアクセスできること
- タイトル、メモ、散歩した日、気分を入力して投稿できること
- 投稿内容がDBに保存されること
- user_id がログインユーザーに紐づいていること

### 関連Isuue
closes #5