### PR TITLE
“散歩記録の一覧ページ（index）を実装”

### DIFF
--- a/app/controllers/walk_records_controller.rb
+++ b/app/controllers/walk_records_controller.rb
@@ -1,6 +1,10 @@
 class WalkRecordsController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @walk_records = current_user.walk_records.order(walked_on: :desc, created_at: :desc)
+  end
+
   def new
     @walk_record = WalkRecord.new
   end
@@ -9,7 +13,7 @@ class WalkRecordsController < ApplicationController
     @walk_record = current_user.walk_records.build(walk_record_params)
 
     if @walk_record.save
-      redirect_to root_path, notice: "散歩記録を投稿しました"
+      redirect_to walk_records_path, notice: "散歩記録を投稿しました"
     else
       flash.now[:alert] = "散歩記録を投稿できませんでした"
       render :new, status: :unprocessable_entity

--- a/app/views/walk_records/index.html.erb
+++ b/app/views/walk_records/index.html.erb
@@ -1,0 +1,42 @@
+<div class="min-h-screen bg-base-200 px-4 py-6">
+  <div class="mx-auto w-full max-w-md">
+    <div class="mb-6 flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold">散歩記録一覧</h1>
+        <p class="mt-1 text-sm text-base-content/70">
+          これまでの散歩記録を確認できます
+        </p>
+      </div>
+
+      <%= link_to "新規投稿", new_walk_record_path, class: "btn btn-primary btn-sm" %>
+    </div>
+
+    <% if @walk_records.any? %>
+      <div class="space-y-4">
+        <% @walk_records.each do |walk_record| %>
+          <div class="card bg-base-100 shadow-md">
+            <div class="card-body">
+              <div class="flex items-start justify-between gap-3">
+                <h2 class="card-title text-lg"><%= walk_record.title %></h2>
+                <span class="badge badge-outline"><%= walk_record.walked_on %></span>
+              </div>
+
+              <p class="text-sm text-base-content/70">
+                気分：<%= walk_record.mood %>
+              </p>
+
+              <p class="whitespace-pre-wrap"><%= walk_record.body %></p>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="card bg-base-100 shadow-md">
+        <div class="card-body text-center">
+          <p class="text-base-content/70">まだ散歩記録がありません</p>
+          <%= link_to "最初の記録を投稿する", new_walk_record_path, class: "btn btn-primary mt-4" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root "pages#home"
 
-  resources :walk_records, only: %i[new create]
+  resources :walk_records, only: %i[new create index]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### 概要
散歩記録の一覧画面（index）を実装。
ログインユーザーが投稿した散歩記録を一覧で確認できる。

### 変更内容
- routes.rbにindexを追加
resources :walk_records, only: %i[new create index]
- WalkRecordsController に index アクションを追加
def index
  @walk_records = current_user.walk_records.order(walked_on: :desc, created_at: :desc)
end
- 一覧画面（index.html.erb）を作成
- [新規投稿]ボタンを追加し、投稿画面へ遷移できるように実装
- 投稿成功時に一覧画面へリダイレクトするよう修正

### 動作確認

- 一覧画面が表示されること
- 「新規投稿」ボタンから投稿画面へ遷移できること
- 投稿後に一覧画面へリダイレクトされること
- 「散歩記録を投稿しました」のフラッシュメッセージが表示されること
- 投稿が一覧に追加されること
- 同じ日付の投稿でも、作成順（新しい順）で上に表示されること

関連Issue
closes #6