### PR TITLE
散歩記録の詳細ページ(show)を実装

### DIFF
--- a/app/controllers/walk_records_controller.rb
+++ b/app/controllers/walk_records_controller.rb
@@ -20,6 +20,10 @@ class WalkRecordsController < ApplicationController
     end
   end
 
+  def show
+    @walk_record = current_user.walk_records.find(params[:id])
+  end
+
   private
 
   def walk_record_params

--- a/app/views/walk_records/index.html.erb
+++ b/app/views/walk_records/index.html.erb
@@ -17,7 +17,9 @@
           <div class="card bg-base-100 shadow-md">
             <div class="card-body">
               <div class="flex items-start justify-between gap-3">
-                <h2 class="card-title text-lg"><%= walk_record.title %></h2>
+                <h2 class="card-title text-lg">
+                  <%= link_to walk_record.title, walk_record_path(walk_record), class: "link link-hover" %>
+                </h2>
                 <span class="badge badge-outline"><%= walk_record.walked_on %></span>
               </div>
 

--- a/app/views/walk_records/show.html.erb
+++ b/app/views/walk_records/show.html.erb
@@ -1,0 +1,28 @@
+<div class="min-h-screen bg-base-200 px-4 py-6">
+  <div class="mx-auto w-full max-w-md">
+    <div class="mb-4">
+      <%= link_to "← 一覧に戻る", walk_records_path, class: "btn btn-ghost btn-sm" %>
+    </div>
+
+    <div class="card bg-base-100 shadow-md">
+      <div class="card-body space-y-6">
+        <div class="space-y-3">
+          <span class="badge badge-outline"><%= @walk_record.walked_on %></span>
+          <h1 class="text-2xl font-bold leading-tight break-words"><%= @walk_record.title %></h1>
+        </div>
+
+        <div class="divider my-0"></div>
+
+        <div>
+          <p class="text-sm text-base-content/70">気分</p>
+          <p class="mt-1 text-base font-medium"><%= @walk_record.mood %></p>
+        </div>
+
+        <div>
+          <p class="text-sm text-base-content/70">ひとことメモ</p>
+          <p class="mt-1 whitespace-pre-wrap leading-relaxed"><%= @walk_record.body %></p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root "pages#home"
 
-  resources :walk_records, only: %i[new create index]
+  resources :walk_records, only: %i[new create index show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### 実装内容
散歩記録の詳細ページ（show）を実装。
一覧画面から各投稿をクリックすることで、1件の詳細情報を確認できる。

### 変更内容

- routes.rb に show を追加
resources :walk_records, only: %i[new create index show]

- WalkRecordsController に show アクションを追加
def show
  @walk_record = current_user.walk_records.find(params[:id])
end

- show.html.erb を作成
- 一覧画面から詳細ページへ遷移できるように修正
<%= link_to walk_record.title, walk_record_path(walk_record) %>
- 一覧ページへ戻るリンクを追加
<%= link_to "← 一覧に戻る", walk_records_path %>

### 動作確認

- 一覧ページから投稿タイトルをクリックすると詳細ページに遷移すること

- 詳細ページに以下の情報が表示されること
タイトル
日付
気分
本文
- 「一覧に戻る」リンクで一覧ページへ戻れること
- ログインしていない場合はアクセスできないこと（認証が機能していること）
- 他ユーザーの投稿にアクセスできないこと（current_userで制限されていること）
  
### 関連Issue
closes #9 