### PR TITLE
散歩記録の編集ページ（edit / update）を実装

### DIFF
--- a/app/controllers/walk_records_controller.rb
+++ b/app/controllers/walk_records_controller.rb
@@ -24,6 +24,21 @@ class WalkRecordsController < ApplicationController
     @walk_record = current_user.walk_records.find(params[:id])
   end
 
+  def edit
+    @walk_record = current_user.walk_records.find(params[:id])
+  end
+
+  def update
+    @walk_record = current_user.walk_records.find(params[:id])
+
+    if @walk_record.update(walk_record_params)
+      redirect_to walk_record_path(@walk_record), notice: "散歩記録を更新しました"
+    else
+      flash.now[:alert] = "散歩記録を更新できませんでした"
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def walk_record_params

--- a/app/views/walk_records/edit.html.erb
+++ b/app/views/walk_records/edit.html.erb
@@ -1,0 +1,79 @@
+<div class="min-h-screen bg-base-200 px-4 py-6">
+  <div class="mx-auto w-full max-w-md">
+    <div class="mb-6 text-center">
+      <h1 class="text-2xl font-bold">散歩記録を編集する</h1>
+      <p class="mt-2 text-sm text-base-content/70">
+        投稿内容を修正できます
+      </p>
+    </div>
+
+    <% if @walk_record.errors.any? %>
+      <div class="alert alert-error mb-4 shadow-sm">
+        <div>
+          <span class="font-bold">
+            <%= @walk_record.errors.count %>件のエラーがあります
+          </span>
+          <ul class="mt-2 list-disc pl-5 text-sm">
+            <% @walk_record.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="card bg-base-100 shadow-md">
+      <div class="card-body">
+        <%= form_with model: @walk_record, local: true, class: "space-y-4" do |f| %>
+          <div class="form-control">
+            <%= f.label :title, class: "label" do %>
+              <span class="label-text font-semibold">タイトル</span>
+            <% end %>
+            <%= f.text_field :title,
+                  placeholder: "例：朝のお散歩",
+                  class: "input input-bordered w-full" %>
+          </div>
+
+          <div class="form-control">
+            <%= f.label :walked_on, class: "label" do %>
+              <span class="label-text font-semibold">散歩した日</span>
+            <% end %>
+            <%= f.date_field :walked_on,
+                  class: "input input-bordered w-full" %>
+          </div>
+
+          <div class="form-control">
+            <%= f.label :mood, class: "label" do %>
+              <span class="label-text font-semibold">気分</span>
+            <% end %>
+            <%= f.select :mood,
+                  [
+                    ["良い", "good"],
+                    ["普通", "normal"],
+                    ["悪い", "bad"],
+                    ["楽しい", "excited"],
+                    ["疲れた", "tired"]
+                  ],
+                  {},
+                  class: "select select-bordered w-full" %>
+          </div>
+
+          <div class="form-control">
+            <%= f.label :body, class: "label" do %>
+              <span class="label-text font-semibold">ひとことメモ</span>
+            <% end %>
+            <%= f.text_area :body,
+                  rows: 5,
+                  placeholder: "今日のおさんぽのことを書いてみましょう",
+                  class: "textarea textarea-bordered w-full" %>
+          </div>
+
+          <div class="pt-2 space-y-2">
+            <%= f.submit "更新する", class: "btn btn-primary w-full" %>
+            <%= link_to "詳細に戻る", walk_record_path(@walk_record), class: "btn btn-ghost w-full" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/walk_records/index.html.erb
+++ b/app/views/walk_records/index.html.erb
@@ -17,10 +17,12 @@
           <div class="card bg-base-100 shadow-md">
             <div class="card-body">
               <div class="flex items-start justify-between gap-3">
-                <h2 class="card-title text-lg">
-                  <%= link_to walk_record.title, walk_record_path(walk_record), class: "link link-hover" %>
+                <h2 class="min-w-0 flex-1 text-lg font-bold leading-tight">
+                  <%= link_to walk_record.title,
+                      walk_record_path(walk_record),
+                      class: "link link-hover break-words" %>
                 </h2>
-                <span class="badge badge-outline"><%= walk_record.walked_on %></span>
+                <span class="badge badge-outline shrink-0"><%= walk_record.walked_on %></span>
               </div>
 
               <p class="text-sm text-base-content/70">

--- a/app/views/walk_records/show.html.erb
+++ b/app/views/walk_records/show.html.erb
@@ -22,6 +22,10 @@
           <p class="text-sm text-base-content/70">ひとことメモ</p>
           <p class="mt-1 whitespace-pre-wrap leading-relaxed"><%= @walk_record.body %></p>
         </div>
+
+        <div class="pt-2">
+          <%= link_to "編集する", edit_walk_record_path(@walk_record), class: "btn btn-primary w-full" %>
+        </div>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root "pages#home"
 
-  resources :walk_records, only: %i[new create index show]
+  resources :walk_records, only: %i[new create index show edit update]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### 概要
散歩記録の編集機能（edit / update）を実装。

### 変更内容

- ルーティングにedit / updateを追加
only: %i[new create index show edit update]
- editアクションの作成
def edit
    @walk_record = current_user.walk_records.find(params[:id])
  end
- updateアクションの作成
def update
    @walk_record = current_user.walk_records.find(params[:id])

    if @walk_record.update(walk_record_params)
      redirect_to walk_record_path(@walk_record), notice: "散歩記録を更新しました"
    else
      flash.now[:alert] = "散歩記録を更新できませんでした"
      render :edit, status: :unprocessable_entity
    end
  end
- 編集フォーム（edit.html.erb）の作成
- 一覧画面のレイアウト崩れ修正（タイトルと日付の表示調整）

### 動作確認
- 一覧画面から投稿を選択し、編集画面に遷移できること
- 既存の投稿内容がフォームに表示されること
- 内容を変更して更新ボタンを押すと、変更内容が保存されること
- 更新後、詳細画面にリダイレクトされること
- 「散歩記録を更新しました」のフラッシュメッセージが表示されること
- 一覧画面でレイアウト崩れが発生しないこと

### 関連Issue
closes #23 