### PR TITLE
散歩記録の削除機能（destroy）を実装

### DIFF
--- a/app/controllers/walk_records_controller.rb
+++ b/app/controllers/walk_records_controller.rb
@@ -39,6 +39,13 @@ class WalkRecordsController < ApplicationController
     end
   end
 
+  def destroy
+    @walk_record = current_user.walk_records.find(params[:id])
+    @walk_record.destroy
+
+    redirect_to walk_records_path, notice: "散歩記録を削除しました"
+  end
+
   private
 
   def walk_record_params

--- a/app/views/walk_records/show.html.erb
+++ b/app/views/walk_records/show.html.erb
@@ -23,8 +23,11 @@
           <p class="mt-1 whitespace-pre-wrap leading-relaxed"><%= @walk_record.body %></p>
         </div>
 
-        <div class="pt-2">
+        <div class="pt-2 space-y-2">
           <%= link_to "編集する", edit_walk_record_path(@walk_record), class: "btn btn-primary w-full" %>
+          <%= link_to "削除する",
+              walk_record_path(@walk_record),
+              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error w-full" %>
         </div>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root "pages#home"
 
-  resources :walk_records, only: %i[new create index show edit update]
+  resources :walk_records, only: %i[new create index show edit update destroy]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### 概要
散歩記録の削除機能（destroy）を実装。
詳細ページより削除が可能。

### 変更内容

- destroyアクションを追加
only: %i[new create index show edit update destroy]
- routesにdestroyを追加
def destroy
    @walk_record = current_user.walk_records.find(params[:id])
    @walk_record.destroy
　redirect_to walk_records_path, notice: "散歩記録を削除しました"
  end
- 詳細ページに削除ボタンを追加
<%= link_to "削除する",
              walk_record_path(@walk_record),
              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" }, class: "btn btn-error w-full" %>
削除時に確認ダイアログを表示（turbo_confirm）
削除後に一覧画面へリダイレクト

### 動作確認

- 詳細ページに削除ボタンが表示されること
- 削除ボタン押下時に確認ダイアログが表示されること
- 「OK」を押すと投稿が削除されること
- 削除後に一覧画面へ遷移すること
- 削除された投稿が一覧から消えていること
- フラッシュメッセージが表示されること

### 関連Issue
cleses #24 