### PR TITLE
mood表示の見た目を修正

### DIFF
--- a/app/models/walk_record.rb
+++ b/app/models/walk_record.rb
@@ -3,6 +3,21 @@ class WalkRecord < ApplicationRecord
 
   enum mood: { good: 0, normal: 1, bad: 2, excited: 3, tired: 4 }
 
+  def mood_label
+    case mood
+    when "good"
+      "良い"
+    when "normal"
+      "ふつう"
+    when "bad"
+      "悪い"
+    when "excited"
+      "楽しい"
+    when "tired"
+      "疲れた"
+    end
+  end
+
   validates :walked_on, presence: true
   validates :body, presence: true
 end

--- a/app/views/walk_records/edit.html.erb
+++ b/app/views/walk_records/edit.html.erb
@@ -49,7 +49,7 @@
             <%= f.select :mood,
                   [
                     ["良い", "good"],
-                    ["普通", "normal"],
+                    ["ふつう", "normal"],
                     ["悪い", "bad"],
                     ["楽しい", "excited"],
                     ["疲れた", "tired"]

--- a/app/views/walk_records/index.html.erb
+++ b/app/views/walk_records/index.html.erb
@@ -26,7 +26,7 @@
               </div>
 
               <p class="text-sm text-base-content/70">
-                気分：<%= walk_record.mood %>
+                気分：<%= walk_record.mood_label%>
               </p>
 
               <p class="whitespace-pre-wrap"><%= walk_record.body %></p>

--- a/app/views/walk_records/new.html.erb
+++ b/app/views/walk_records/new.html.erb
@@ -49,7 +49,7 @@
             <%= f.select :mood,
                   [
                     ["良い", "good"],
-                    ["普通", "normal"],
+                    ["ふつう", "normal"],
                     ["悪い", "bad"],
                     ["楽しい", "excited"],
                     ["疲れた", "tired"]

--- a/app/views/walk_records/show.html.erb
+++ b/app/views/walk_records/show.html.erb
@@ -15,7 +15,7 @@
 
         <div>
           <p class="text-sm text-base-content/70">気分</p>
-          <p class="mt-1 text-base font-medium"><%= @walk_record.mood %></p>
+          <p class="mt-1 text-base font-medium"><%= @walk_record.mood_label %></p>
         </div>
 
         <div>


### PR DESCRIPTION
### 概要
散歩記録の気分（mood）を、日本語表示に修正。
### 変更内容
- 気分の日本語表示用メソッドをWalkRecord モデルに追加
 def mood_label....
- 一覧画面（index）で気分を日本語表示に変更
気分：<%= walk_record.mood_label%>
- 詳細画面（show）で気分を日本語表示に変更
気分：<%= walk_record.mood_label%>

### 動作確認

- 一覧画面で気分が日本語表示されること
- 詳細画面で気分が日本語表示されること
- 保存後も正しく日本語表示されること

### 関連Issue
closes #10 