### PR TITLE
Theme / Challengeモデル・テーブル作成

### DIFF
--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -1,0 +1,10 @@
+class Challenge < ApplicationRecord
+  belongs_to :user
+  belongs_to :theme
+
+  enum status: { in_progress: 0, completed: 1 }
+
+  validates :started_on, presence: true
+  validates :progress_count,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 7 }
+end

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,0 +1,5 @@
+class Theme < ApplicationRecord
+  has_many :challenges, dependent: :restrict_with_exception
+
+  validates :name, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :walk_records, dependent: :destroy
+  has_many :challenges, dependent: :destroy
 end

--- a/db/migrate/20260330104502_create_themes.rb
+++ b/db/migrate/20260330104502_create_themes.rb
@@ -1,0 +1,12 @@
+class CreateThemes < ActiveRecord::Migration[7.2]
+  def change
+    create_table :themes do |t|
+      t.string :name, null: false
+      t.text :description
+      t.string :image_path
+      t.boolean :active, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260330104540_create_challenges.rb
+++ b/db/migrate/20260330104540_create_challenges.rb
@@ -1,0 +1,14 @@
+class CreateChallenges < ActiveRecord::Migration[7.2]
+  def change
+    create_table :challenges do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :theme, null: false, foreign_key: true
+      t.integer :progress_count, null: false, default: 0
+      t.integer :status, null: false, default: 0
+      t.date :started_on, null: false
+      t.datetime :completed_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_19_102338) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_30_104540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "challenges", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "theme_id", null: false
+    t.integer "progress_count", default: 0, null: false
+    t.integer "status", default: 0, null: false
+    t.date "started_on", null: false
+    t.datetime "completed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["theme_id"], name: "index_challenges_on_theme_id"
+    t.index ["user_id"], name: "index_challenges_on_user_id"
+  end
+
+  create_table "themes", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.string "image_path"
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -37,5 +59,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_19_102338) do
     t.index ["user_id"], name: "index_walk_records_on_user_id"
   end
 
+  add_foreign_key "challenges", "themes"
+  add_foreign_key "challenges", "users"
   add_foreign_key "walk_records", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,8 @@
-# This file should ensure the existence of records required to run the application in every environment (production,
+Theme.find_or_create_by!(name: "桜") do |theme|
+  theme.description = "散歩記録を7回投稿して、桜のボード完成を目指すチャレンジです。"
+  theme.image_path = "sakura_theme.png"
+  theme.active = true
+end# This file should ensure the existence of records required to run the application in every environment (production,
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #


### PR DESCRIPTION
### 概要
チャレンジ機能の基盤となるTheme・Challengeモデルとテーブルを作成。
### 変更内容
・Themeモデルを作成
（generate model Theme name:string description:text image_path:string active:boolean）

・Challengeモデルを作成
（generate model Challenge user:references theme:references progress_count:integer status:integer started_on:date completed_at:datetime）

・マイグレーションファイルを作成・実行
docker compose exec web bin/rails db:migrate

・themesテーブルを作成
【カラム】
name:string
description:text
image_path:string
active:boolean

・challengesテーブルを作成
【カラム】
user:references
theme:references
progress_count:integer
status:integer
started_on:date
completed_at:datetime

・モデルの関連付けを実装
Theme：has_many :challenges
Challenge：belongs_to :user
Challenge：belongs_to :theme

・Challengeモデルにenumを定義
enum status { in_progress: 0, completed: 1 }

・バリデーションを追加
Theme：nameの存在チェック
Challenge：started_onの存在チェック
Challenge：progress_countの数値制限（0〜7）

・seedデータに桜テーマを追加

### 関連Issue
closes #35 