### PR TITLE
ChallengesControllerとroutesを作成

### DIFF
--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -1,0 +1,33 @@
+class ChallengesController < ApplicationController
+  before_action :authenticate_user!
+
+  def new
+    @theme = Theme.find_by!(name: "桜")
+  end
+
+  def create
+    existing_challenge = current_user.challenges.find_by(status: :in_progress)
+    if existing_challenge.present?
+      redirect_to challenge_path, alert: "すでに進行中のチャレンジがあります"
+      return
+    end
+
+    theme = Theme.find_by!(name: "桜")
+    current_user.challenges.create!(
+      theme: theme,
+      progress_count: 0,
+      status: :in_progress,
+      started_on: Date.current
+    )
+
+    redirect_to challenge_path, notice: "チャレンジを開始しました"
+  end
+
+  def show
+    @challenge = current_user.challenges.find_by(status: :in_progress)
+    if @challenge.nil?
+      redirect_to new_challenge_path, alert: "進行中のチャレンジがありません"
+      nil
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   root "pages#home"
 
   resources :walk_records, only: %i[new create index show edit update destroy]
+
+  resource :challenge, only: %i[new create show]
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
### 概要
チャレンジ機能の開始・表示を行うためのルーティングとコントローラを作成。

### 変更内容

・ルーティングを追加
resource :challenge, only: %i[new create show]

・ChallengesControllerを作成
docker compose exec web bin/rails generate controller Challenges

・before_action :authenticate_user! を追加
ログインユーザーのみアクセス可能に制御

・newアクションを実装
桜テーマを取得し、チャレンジ説明画面に表示

・createアクションを実装
進行中チャレンジの存在チェック
既に存在する場合は新規作成しない
[チャレンジ作成処理]
themeを紐付け
progress_countを0で初期化
statusをin_progressに設定
started_onを当日で設定
作成後、チャレンジ詳細画面へリダイレクト

・showアクションを実装
進行中または最新のチャレンジを取得
チャレンジが存在しない場合はnew画面へリダイレクト

### 関連Issue
closes #37 