### PR TITLE
テーマ説明画面・チャレンジ詳細画面・一覧画面の導線作成

### DIFF
--- a/app/controllers/walk_records_controller.rb
+++ b/app/controllers/walk_records_controller.rb
@@ -3,6 +3,7 @@ class WalkRecordsController < ApplicationController
 
   def index
     @walk_records = current_user.walk_records.order(walked_on: :desc, created_at: :desc)
+    @current_challenge = current_user.challenges.find_by(status: :in_progress)
   end
 
   def new

--- a/app/views/challenges/new.html.erb
+++ b/app/views/challenges/new.html.erb
@@ -1,0 +1,22 @@
+<div class="max-w-2xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-4">7日間チャレンジ</h1>
+
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body">
+      <h2 class="card-title"><%= @theme.name %>テーマ</h2>
+
+      <p class="mb-4">
+        <%= @theme.description %>
+      </p>
+
+      <p class="mb-6">
+        散歩記録を7回投稿すると、テーマボードが完成します。
+      </p>
+
+      <div class="flex gap-3">
+        <%= button_to "7日間チャレンジスタート", challenge_path, method: :post, class: "btn btn-primary" %>
+        <%= link_to "一覧へ戻る", walk_records_path, class: "btn btn-outline" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/challenges/show.html.erb
+++ b/app/views/challenges/show.html.erb
@@ -1,0 +1,37 @@
+<div class="max-w-2xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-4">チャレンジ詳細</h1>
+
+  <div class="card bg-base-100 shadow-md mb-6">
+    <div class="card-body">
+      <h2 class="card-title"><%= @challenge.theme.name %>テーマ</h2>
+
+      <p class="mb-2">
+        進捗: <%= @challenge.progress_count %> / 7
+      </p>
+
+      <p class="mb-4">
+        開始日: <%= @challenge.started_on %>
+      </p>
+
+      <div class="flex gap-2 text-2xl mb-4">
+        <% 7.times do |i| %>
+          <% if i < @challenge.progress_count %>
+            <span>🌸</span>
+          <% else %>
+            <span>□</span>
+          <% end %>
+        <% end %>
+      </div>
+
+      <% if @challenge.completed? %>
+        <p class="text-success font-bold">おめでとうございます！チャレンジ達成です！</p>
+      <% else %>
+        <p>あと <%= 7 - @challenge.progress_count %> 回で完成です。</p>
+      <% end %>
+
+      <div class="mt-6">
+        <%= link_to "一覧へ戻る", walk_records_path, class: "btn btn-outline" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/walk_records/index.html.erb
+++ b/app/views/walk_records/index.html.erb
@@ -1,5 +1,17 @@
 <div class="min-h-screen bg-base-200 px-4 py-6">
   <div class="mx-auto w-full max-w-md">
+
+    <% if @current_challenge.present? %>
+      <div class="mb-6">
+        <p class="mb-2">今の進捗: <%= @current_challenge.progress_count %> / 7</p>
+        <%= link_to "チャレンジ詳細を見る", challenge_path, class: "btn btn-primary" %>
+      </div>
+    <% else %>
+      <div class="mb-6">
+        <%= link_to "桜の7日間チャレンジを始める", new_challenge_path, class: "btn btn-primary" %>
+      </div>
+    <% end %>
+
     <div class="mb-6 flex items-center justify-between">
       <div>
         <h1 class="text-2xl font-bold">散歩記録一覧</h1>


### PR DESCRIPTION
### 概要

チャレンジ機能にアクセスするための画面と導線を実装。

### 変更内容
・チャレンジ説明画面を作成
app/views/challenges/new.html.erb 
テーマ名、説明文を表示
「7日間チャレンジスタート」ボタンを設置
一覧画面へ戻るリンクを設置

・チャレンジ詳細画面を作成
app/views/challenges/show.html.erb を作成
テーマ名、進捗、開始日を表示
7マスUIで進捗状況を表示
未達成時は残り回数を表示
一覧画面へ戻るリンクを設置

・WalkRecordsController#index を修正
@current_challenge を追加し、現在のチャレンジを取得するように変更

・一覧画面にチャレンジ導線を追加
未開始時
「桜の7日間チャレンジを始める」ボタンを表示

・進行中時
進捗（○ / 7）を表示
「チャレンジ詳細を見る」ボタンを表示

### 動作確認
ブラウザにて以下を確認
・一覧画面にチャレンジ開始ボタンが表示されること
・チャレンジ開始ボタン押下で説明画面に遷移すること
・説明画面にテーマ名、説明文、スタートボタンが表示されること
・スタートボタン押下でチャレンジが開始されること
・チャレンジ詳細画面に進捗、開始日、7マスUIが表示されること
・進行中の場合、一覧画面に進捗と詳細リンクが表示されること

### 関連Issue
closes #39 