### PR TITLE
週次振り返り機能用のWeeklyReflectionモデルとテーブルを作成

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,5 @@ class User < ApplicationRecord
 
   has_many :walk_records, dependent: :destroy
   has_many :challenges, dependent: :destroy
+  has_many :weekly_reflections, dependent: :destroy
 end

--- a/app/models/weekly_reflection.rb
+++ b/app/models/weekly_reflection.rb
@@ -2,5 +2,5 @@ class WeeklyReflection < ApplicationRecord
   belongs_to :user
 
   validates :start_date, :end_date, presence: true
-  validates :start_date, uniqueness: { scope: [:user_id, :end_date] }
+  validates :start_date, uniqueness: { scope: [ :user_id, :end_date ] }
 end

--- a/app/models/weekly_reflection.rb
+++ b/app/models/weekly_reflection.rb
@@ -1,0 +1,6 @@
+class WeeklyReflection < ApplicationRecord
+  belongs_to :user
+
+  validates :start_date, :end_date, presence: true
+  validates :start_date, uniqueness: { scope: [:user_id, :end_date] }
+end

--- a/db/migrate/20260421102949_create_weekly_reflections.rb
+++ b/db/migrate/20260421102949_create_weekly_reflections.rb
@@ -11,6 +11,6 @@ class CreateWeeklyReflections < ActiveRecord::Migration[7.2]
       t.timestamps
     end
 
-    add_index :weekly_reflections, [:user_id, :start_date, :end_date], unique: true
+    add_index :weekly_reflections, [ :user_id, :start_date, :end_date ], unique: true
   end
 end

--- a/db/migrate/20260421102949_create_weekly_reflections.rb
+++ b/db/migrate/20260421102949_create_weekly_reflections.rb
@@ -1,0 +1,16 @@
+class CreateWeeklyReflections < ActiveRecord::Migration[7.2]
+  def change
+    create_table :weekly_reflections do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :start_date, null: false
+      t.date :end_date, null: false
+      t.text :summary
+      t.text :analysis
+      t.text :encouragement
+
+      t.timestamps
+    end
+
+    add_index :weekly_reflections, [:user_id, :start_date, :end_date], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_08_111353) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_21_102949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,7 +60,21 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_08_111353) do
     t.index ["user_id"], name: "index_walk_records_on_user_id"
   end
 
+  create_table "weekly_reflections", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "start_date", null: false
+    t.date "end_date", null: false
+    t.text "summary"
+    t.text "analysis"
+    t.text "encouragement"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "start_date", "end_date"], name: "idx_on_user_id_start_date_end_date_464d9844e4", unique: true
+    t.index ["user_id"], name: "index_weekly_reflections_on_user_id"
+  end
+
   add_foreign_key "challenges", "themes"
   add_foreign_key "challenges", "users"
   add_foreign_key "walk_records", "users"
+  add_foreign_key "weekly_reflections", "users"
 end


### PR DESCRIPTION
### 概要
週次振り返り機能の実装に向けて、
振り返り結果を保存するためのWeeklyReflectionモデルおよびテーブルを作成。

### 変更内容

- WeeklyReflectionモデルを作成
- weekly_reflectionsテーブルを作成
- 以下のカラムを追加
user_id
start_date (週の開始日)
end_date (週の終了日)
summary　（要約）
analysis:text  （傾向）
encouragement:text （励ましのひとこと）
- Userモデルに関連付けを追加
has_many :weekly_reflections
- WeeklyReflectionモデルに関連付けを追加
belongs_to :user
- バリデーションを追加
同一ユーザー・同一週の重複防止（一意性制約）
- DB側に一意インデックスを追加
[:user_id, :start_date, :end_date]

### 動作確認

db:migrate が正常に実行できることを確認
schema.rb に weekly_reflections テーブルが追加されていることを確認

### 関連Issue
Closes #60 