### PR TITLE
週次振り返り対象の散歩記録取得処理を作成

### DIFF
--- a/app/services/weekly_reflection_target.rb
+++ b/app/services/weekly_reflection_target.rb
@@ -1,0 +1,25 @@
+class WeeklyReflectionTarget
+  def initialize(user:, start_date:, end_date:)
+    @user = user
+    @start_date = start_date
+    @end_date = end_date
+  end
+
+  def records
+    @user.walk_records.where(walked_on: @start_date..@end_date).order(:walked_on)
+  end
+
+  def prompt_text
+    records.map do |record|
+      "#{record.walked_on} / 気分: #{record.mood} / コメント: #{record.body}"
+    end.join("\n")
+  end
+
+  def record_count
+    records.count
+  end
+
+  def empty?
+    records.empty?
+  end
+end


### PR DESCRIPTION
### 概要
指定した1週間分の散歩記録を取得し、
GPTに送るための形式に整形する処理を実装。

### 変更内容
- 指定した期間の walk_records を取得する処理を実装
- 対象週（開始日〜終了日）を指定してデータを取得できるようにした
- 散歩記録をGPTに送るための文字列に整形する処理を実装
日付
気分
本文
- 上記処理を WeeklyReflectionTarget サービスクラスとして実装
  - records
  - prompt_text
  - record_count
  - empty? メソッドを追加

 ※空本文の除外および文字数制限については、OpenAI API連携時に対応予定とする

### 動作確認
Rails consoleにて以下を確認
- 指定週の散歩記録が取得できること
- record_count が正しい件数を返すこと
- empty? が正しく判定されること
- prompt_text が想定通りの形式で生成されること

### 関連Issue
Closes #61 