### PR TITLE
週次振り返り結果の分割およびDB保存処理を実装

### DIFF
--- a/app/services/weekly_reflection_generator.rb
+++ b/app/services/weekly_reflection_generator.rb
@@ -1,24 +1,32 @@
-require "openai"
-
 class WeeklyReflectionGenerator
-  def initialize(prompt_text:)
-    @prompt_text = prompt_text
+  def initialize(user:, start_date:, end_date:)
+    @user = user
+    @start_date = start_date
+    @end_date = end_date
   end
 
   def call
+    target = WeeklyReflectionTarget.new(
+      user: @user,
+      start_date: @start_date,
+      end_date: @end_date
+    )
+
     client = OpenAI::Client.new
 
     response = client.responses.create(
       model: "gpt-4o-mini",
-      input: build_prompt
+      input: build_prompt(target.prompt_text)
     )
 
-    response.output_text
+    parsed = parse_response(response.output_text)
+
+    save_reflection(parsed)
   end
 
   private
 
-  def build_prompt
+  def build_prompt(prompt_text)
     <<~TEXT
     以下は1週間の散歩記録です。
     この内容をもとに、次の3つを日本語で作成してください。
@@ -29,7 +37,30 @@ class WeeklyReflectionGenerator
 
     ----
 
-    #{@prompt_text}
+    #{prompt_text}
     TEXT
+  end
+
+  def parse_response(text)
+    parts = text.split("### ")
+
+    {
+      summary: parts[1]&.split("\n", 2)&.last&.strip,
+      analysis: parts[2]&.split("\n", 2)&.last&.strip,
+      encouragement: parts[3]&.split("\n", 2)&.last&.strip
+    }
+  end
+
+  def save_reflection(data)
+    WeeklyReflection.find_or_initialize_by(
+      user: @user,
+      start_date: @start_date,
+      end_date: @end_date
+    ).tap do |reflection|
+      reflection.summary = data[:summary]
+      reflection.analysis = data[:analysis]
+      reflection.encouragement = data[:encouragement]
+      reflection.save!
+    end
   end
 end


### PR DESCRIPTION
### 概要
週次振り返り機能において、OpenAI APIから取得した結果を分割し、
WeeklyReflection テーブルに保存する処理を実装。

### 変更内容

- GPTの返却結果（文字列）を以下の3つに分割する処理を実装
  - summary（今週の要約）
  - analysis（気分や行動の傾向）
  - encouragement（次週に向けたやさしい一言）
- 分割したデータをHash形式に整形する処理を実装
- WeeklyReflectionGenerator に保存処理を追加
  - WeeklyReflection にデータを保存する処理を実装
- find_or_initialize_by を使用し、同一ユーザー・同一週の重複保存を防止
  - 既存データがある場合は更新処理を行うように実装
- 振り返り生成〜保存までを1つの処理として統合

### 動作確認
- Rails consoleにて以下を確認
GPTの返却結果が正しく分割されること
分割したデータがHash形式で取得できること
WeeklyReflection にデータが保存されること

### 関連Issue
Closes #70 
